### PR TITLE
Use `pk` attribute of model to search by primary key.

### DIFF
--- a/snorky/backend/django/__init__.py
+++ b/snorky/backend/django/__init__.py
@@ -87,7 +87,7 @@ def handle_pre_save(sender, instance, raw, using, update_fields, **kwargs):
 
     If the item did exist before, stores an update delta in ``_snorky_delta``.
     """
-    existent_object_query = sender.objects.filter(id=instance.id)
+    existent_object_query = sender.objects.filter(pk=instance.pk)
     created = (len(existent_object_query) == 0)
     if not created:
         new_data = instance.jsonify()


### PR DESCRIPTION
The use of `id` is problematic because it only works for automatically added
primary keys and not for custom ones.
See Django model instance reference[0] for a rationale.

[0] https://docs.djangoproject.com/en/1.10/ref/models/instances/#the-pk-property
